### PR TITLE
Ensure that block-passing calling style works. Fixes #3.

### DIFF
--- a/lib/open-uri/redirections_patch.rb
+++ b/lib/open-uri/redirections_patch.rb
@@ -29,7 +29,7 @@ module OpenURI
   #
   # The original open_uri takes *args but then doesn't do anything with them.
   # Assume we can only handle a hash.
-  def self.open_uri(name, options = {})
+  def self.open_uri(name, options = {}, &block)
     allow_redirections = options.delete :allow_redirections
 
     case allow_redirections
@@ -50,6 +50,6 @@ module OpenURI
       end
     end
 
-    self.open_uri_original name, options
+    self.open_uri_original name, options, &block
   end
 end

--- a/spec/redirections_spec.rb
+++ b/spec/redirections_spec.rb
@@ -34,6 +34,12 @@ describe "OpenURI" do
       it "should follow safe redirections" do
         open("http://safe.com", :allow_redirections => :safe).read.should == "Hello, this is Safe."
       end
+
+      it "should follow safe redirections with block" do
+        expect { |b| 
+          open("http://safe.com", :allow_redirections => :safe, &b)
+        }.to yield_control
+      end
     end
 
     describe ":allow_redirections => :all" do
@@ -55,6 +61,18 @@ describe "OpenURI" do
 
       it "should follow unsafe redirections" do
         open("https://unsafe.com", :allow_redirections => :all).read.should == "Hello, this is Unsafe."
+      end
+
+      it "should follow safe redirections with block" do
+        expect { |b| 
+          open("http://safe.com", :allow_redirections => :all, &b)
+        }.to yield_control
+      end
+
+      it "should follow unsafe redirections with block" do
+        expect { |b| 
+          open("https://unsafe.com", :allow_redirections => :all, &b)
+        }.to yield_control
       end
     end
   end


### PR DESCRIPTION
Fix #3 by ensuring that block-passing calling style is supported.  For instance:

``` ruby
open("https://www.mint.com") do |f|
  puts f.status
end
```
